### PR TITLE
Portal 2

### DIFF
--- a/src/ts/game/raycast.ts
+++ b/src/ts/game/raycast.ts
@@ -198,9 +198,12 @@ export class RayCast {
             const castResult = RayCast.ray(newPos, newDir, newPlane, cameraX, world, stopOnSprite, perpWallDist + startLength, maxLength);
 
             if ( castResult.sprites.length > 0) {
-                const offset = new Vector(mapX - originPos.x, mapY - originPos.y).rotateBy(angleOffset)
-                        .add(newPos.subtract(worldObject.targetPosition))
-                        .add(worldObject.targetDirection.rotateBy(angleOffset))
+                let offset = new Vector(wallX * side, !side ? wallX : 0)
+                        .add(worldObject.targetDirection)
+                if (offset.x < 0) { offset.x++;}
+                if (offset.y < 0) { offset.y++;}
+
+                offset = offset.add(new Vector(mapX - originPos.x, mapY - originPos.y));
 
                 // Reinterpret sprite position for all sprites discovered by the ray from the portal           
                 castResult.sprites.forEach(s => {

--- a/src/ts/presentation/rendering/renderer.ts
+++ b/src/ts/presentation/rendering/renderer.ts
@@ -160,15 +160,15 @@ export class Renderer {
         });
 
         // Draw sprite positions on screen for debug purposes
-        let y = 14;
-        this.drawContext.fillStyle = "#fff";
-        this.drawContext.font = "12px Courier New";
-        this.drawContext.textAlign = "left";
+        //let y = 14;
+        //this.drawContext.fillStyle = "#fff";
+        //this.drawContext.font = "12px Courier New";
+        //this.drawContext.textAlign = "left";
         
         sprites.forEach(s => {
             this.renderSpriteBillboard(s, game, zBuffer, pitch, spriteTextures);
-            this.drawContext.fillText(`${s.x.toFixed(3)},${s.y.toFixed(3)}`, 8, y);
-            y+= 14;
+            //this.drawContext.fillText(`${s.x.toFixed(3)},${s.y.toFixed(3)}`, 8, y);
+            //y+= 14;
         });
     }
 


### PR DESCRIPTION
The existing approach attempts to reverse the transformations made to the portal entrance hit to get starting position for the exiting ray. The problem with this is that some information was lost in the conversion to "tile space" (between 0 and 1), so you can't simply reverse those transformations to get the original values. Fortunately, just calculating the hit coordinates from scratch is actually much simpler.

![image](https://github.com/NinovanderMark/WebLabyrinth/assets/3503797/43ebb22a-e7ee-4f05-a6d5-161e0a6714c9)